### PR TITLE
display SKIP for tests with skip attribute present in spec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "zzapi-vscode",
+  "name": "zzapi",
   "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "zzapi-vscode",
+      "name": "zzapi",
       "version": "2.2.0",
       "dependencies": {
         "yaml": "^2.4.3",

--- a/src/getResponse.ts
+++ b/src/getResponse.ts
@@ -39,21 +39,23 @@ function getFormattedResult(
   size: number,
   execTime: string | number,
 ): string {
-  function getResultData(res: SpecResult): [number, number] {
+  function getResultData(res: SpecResult): [number, number, boolean] {
     const rootResults = res.results;
     let passed = !res.skipped ? rootResults.filter((r) => r.pass).length : 0,
       all = !res.skipped ? rootResults.length : 0;
 
+    let hasSkip: boolean = res.skipped ?? false;
     for (const s of res.subResults) {
-      const [subPassed, subAll] = getResultData(s);
+      const [subPassed, subAll, subSkip] = getResultData(s);
       passed += subPassed;
       all += subAll;
+      hasSkip = hasSkip || subSkip;
     }
 
-    return [passed, all];
+    return [passed, all, hasSkip];
   }
 
-  const [passed, all] = getResultData(specRes);
+  const [passed, all, hasSkip] = getResultData(specRes);
 
   let message = `${new Date().toLocaleString()} `;
   message += all === passed ? "[INFO] " : "[ERROR] ";
@@ -62,7 +64,7 @@ function getFormattedResult(
   message += `${method} ${name} status: ${status} size: ${size} B time: ${execTime} ${testString}`;
 
   function getResult(res: SpecResult, preSpec?: string): string {
-    if (passed === all) return "";
+    if (passed === all && !hasSkip) return "";
 
     const getFullSpec = (): string => {
       if (!res.spec) return "";


### PR DESCRIPTION
**NOTE**: This depends on [the PR in zzapi](https://github.com/agrostar/zzapi/pull/8) that introduces thee `$skip` clause. 

- display *SKIP* for tests with `$skip` attribute present in their spec.
- expand all test results in case of any present `$skip` clause in spec itself or any sub-spec. 