### PR TITLE
removing user-agent header from curl requests

### DIFF
--- a/src/reformatRequest.ts
+++ b/src/reformatRequest.ts
@@ -36,7 +36,8 @@ function formatAndReplaceVars(
   curlReq?: boolean,
 ): string[] {
   const autoHeaders: { [key: string]: string } = {};
-  autoHeaders["user-agent"] = "zzAPI-vscode/" + extensionVersion;
+  if (!curlReq) autoHeaders["user-agent"] = "zzAPI-vscode/" + extensionVersion;
+
   if (request.httpRequest.body && typeof request.httpRequest.body == "object")
     autoHeaders["content-type"] = "application/json";
   request.httpRequest.headers = Object.assign(autoHeaders, request.httpRequest.headers);


### PR DESCRIPTION
- allowing cURL to set its own user-agent header, instead of specifying a zzAPI one. 